### PR TITLE
WAM NetCDF Output

### DIFF
--- a/scripts/compsets/config/wam-ipe_dpnamelist.config
+++ b/scripts/compsets/config/wam-ipe_dpnamelist.config
@@ -24,12 +24,13 @@ ref_pres=${ref_pres:-101.325}
 nemsio_in=${NEMSIO_IN:-.false.}
 nemsio_out=${NEMSIO_OUT:-.false.}
 zflxtvd=${zflxtvd:-.false.}
-nc_output=${nc_output:-.true.}
-fhout_nc=${fhout_nc:-1}
+nc_output=${nc_output:-.false.}
+delout_nc=${delout_nc:-3600}
+nc_fields=${nc_fields:-.true.} # w, z, u, v, t,qr,o3,clw, o,o2,n2,den,gmol
 # build list of variables
 dynvars="sigio_out shuff_lats_a hdif_fac hdif_fac2 settls_dep3ds settls_dep3dg redgg_a"
 dynvars="$dynvars gg_tracers sl_epsln ref_temp yhalo phigs_d ldfi_spect cdamp zflxtvd lsidea"
-dynvars="$dynvars nemsio_in nemsio_out nc_output fhout_nc"
+dynvars="$dynvars nemsio_in nemsio_out nc_output delout_nc nc_fields"
 
 # put them in the namelist variable, passed to exglobal_fcst_nems.sh
 for var in $dynvars ; do

--- a/scripts/compsets/config/wam-ipe_dpnamelist.config
+++ b/scripts/compsets/config/wam-ipe_dpnamelist.config
@@ -24,11 +24,12 @@ ref_pres=${ref_pres:-101.325}
 nemsio_in=${NEMSIO_IN:-.false.}
 nemsio_out=${NEMSIO_OUT:-.false.}
 zflxtvd=${zflxtvd:-.false.}
-
+nc_output=${nc_output:-.true.}
+fhout_nc=${fhout_nc:-1}
 # build list of variables
 dynvars="sigio_out shuff_lats_a hdif_fac hdif_fac2 settls_dep3ds settls_dep3dg redgg_a"
 dynvars="$dynvars gg_tracers sl_epsln ref_temp yhalo phigs_d ldfi_spect cdamp zflxtvd lsidea"
-dynvars="$dynvars nemsio_in nemsio_out"
+dynvars="$dynvars nemsio_in nemsio_out nc_output fhout_nc"
 
 # put them in the namelist variable, passed to exglobal_fcst_nems.sh
 for var in $dynvars ; do

--- a/scripts/compsets/coupled_20130316.config
+++ b/scripts/compsets/coupled_20130316.config
@@ -19,10 +19,16 @@ export FHMAX=1 # hours to forecast from input files. think of this as a segment 
 export FHRES=1 # hours between writing restart files
 export FHOUT=1 # frequency of standard history file output (hours)
 export FHDFI=0 # half number of hours of digital filter initialization
+export nc_output=F
+export delout_nc=3600
+export nc_fields="F, F, T, T, T, F, F, F, F, F, F, T, T"
+###############   w, z, u, v, t,qr,o3,cw, o,o2,n2,den,gmol
+
 # IPE IO options
 # IPEFREQ will default to DELTIM if unset but is required to be <=FHMAX and a multiple of DELTIM
 export IPEFREQ=3600 # seconds between IPE output
 
+# model timestep options
 export DELTIM=60      # GSM timestep
 export DELTIM_IPE=180 # IPE timestep
 

--- a/scripts/compsets/exglobal/exglobal_fcst_nems.sh
+++ b/scripts/compsets/exglobal/exglobal_fcst_nems.sh
@@ -1247,8 +1247,9 @@ if [ $NEMS = .true. ] ; then # grids for mediator
 fi
 
 if [ $IDEA = .true. ]; then
-  START_UT_SEC=$((10#$INI_HOUR*3600))
+  ${NLN} $COMOUT/wam_fields_${CDATE}_${cycle}.nc $DATA/wam_fields.nc
 
+  START_UT_SEC=$((10#$INI_HOUR*3600))
   if [ $INPUT_PARAMETERS = realtime ] ; then
     # copy in xml kp/f107
     XML_HOUR=`printf %02d $((10#$INI_HOUR / 3 * 3))` # 00 > 00, 01 > 00, 02 > 00, 03 > 03, etc.

--- a/scripts/compsets/march2013_regression.config
+++ b/scripts/compsets/march2013_regression.config
@@ -19,15 +19,21 @@ export FHMAX=1 # hours to forecast from input files. think of this as a segment 
 export FHRES=1 # hours between writing restart files
 export FHOUT=1 # frequency of standard history file output (hours)
 export FHDFI=0 # half number of hours of digital filter initialization
+export nc_output=F
+export delout_nc=3600
+export nc_fields="F, F, T, T, T, F, F, F, F, F, F, T, T"
+###############   w, z, u, v, t,qr,o3,cw, o,o2,n2,den,gmol
+
 # IPE IO options
 # IPEFREQ will default to DELTIM if unset but is required to be <=FHMAX and a multiple of DELTIM
 export IPEFREQ=3600 # seconds between IPE output
 
+# model timestep options
 export DELTIM=60      # GSM timestep
 export DELTIM_IPE=180 # IPE timestep
 
 ## computational configuration (compute.config)
-export WALLCLOCK=00:05:00 # minutes
+export WALLCLOCK=00:30:00 # minutes
 # below only used if WAM_IPE_COUPLING=.true.
 export NPROCGSM=32
 export NPROCIPE=40

--- a/scripts/compsets/submit.sh
+++ b/scripts/compsets/submit.sh
@@ -4,7 +4,7 @@ pwd=$(pwd)
 bn=$(basename $1)
 
 ## set restart
-cycle=${2:-1}
+export cycle=${2:-1}
 if [[ $cycle == 1 ]] ; then
   export RESTART=.false.
 else


### PR DESCRIPTION
New, optional WAM NetCDF output is linked into the ROTDIR with $CDATE and $cycle naming. The namelist options controlling this output have been exposed in the default .config files in the WAM I/O section.