### PR TITLE
Wam_namelist _ak

### DIFF
--- a/scripts/compsets/exglobal/exglobal_fcst_nems.sh
+++ b/scripts/compsets/exglobal/exglobal_fcst_nems.sh
@@ -669,6 +669,20 @@ export F107_KP_INTERVAL=${F107_KP_INTERVAL:-10800}
 export IPEFREQ=${IPEFREQ:-3600}
 export IPEFMAX=${IPEFMAX:-$((FHMAX*3600))}
 
+## wam_control_in
+export JH0=${JH0:-1.75}
+export JH_tanh=${JH_tanh:-0.5}
+export JH_semiann=${JH_semiann:-0.5}
+export JH_ann=${JH_ann:-0.0}
+
+export skeddy0=${skeddy0:-140.0}
+export skeddy_semiann=${skeddy_semiann:-60.0}
+export skeddy_ann=${skeddy_ann:-0.0}
+
+export tkeddy0=${tkeddy0:-280.0}
+export tkeddy_semiann=${tkeddy_semiann:-0.0}
+export tkeddy_ann=${tkeddy_ann:-0.0}
+
 ## for post
 export WRITE_DOPOST=${WRITE_DOPOST:-.false.}
 export GOCART_AER2POST=${GOCART_AER2POST:-.false.}

--- a/scripts/compsets/parm/wam_control_in
+++ b/scripts/compsets/parm/wam_control_in
@@ -2,7 +2,10 @@
      wam_climate=.false., wam_swpc_3day=.true., wam_cires_rdata=.false.,
      wam_swin = .true.,
      wam_smin=.false., wam_smax=.false., wam_saver=.true., wam_geostorm=.false.,
-     wam_gwphys=.false., wam_solar_in=.false., wam_ion_in=.false.
-     wam_das_in=.false., wam_smet_in=.false., wam_netcdf_inout=.true.
-     wam_tides_diag=.false., wam_pws_diag=.false., wam_gws_diag=.false.
+     wam_gwphys=.false., wam_solar_in=.false., wam_ion_in=.false.,
+     wam_das_in=.false., wam_smet_in=.false., wam_netcdf_inout=.true.,
+     wam_tides_diag=.false., wam_pws_diag=.false., wam_gws_diag=.false.,
+     JH0=$JH0, JH_tanh=$JH_tanh, JH_semiann=$JH_semiann, JH_ann=$JH_ann,
+     skeddy0=$skeddy0, skeddy_semiann=$skeddy_semiann, skeddy_ann=$skeddy_ann,
+     tkeddy0=$tkeddy0, tkeddy_semiann=$tkeddy_semiann, tkeddy_ann=$tkeddy_ann
 /


### PR DESCRIPTION
This branch includes the code work to add 12 WAM physics parameters as the namelist variables for WAM. 
The parameters includes JH0, JH_tanh, JH_semiann, JH_ann, skeddy0, skeddy_semiann, skeddy_ann,
tkeddy0, tkeddy_semiann, tkeddy_ann. 
I have got the bit by bit same wam output by this branch with the former WAM version. 