### PR TITLE
Add ability to select output fields to SWIO

### DIFF
--- a/scripts/compsets/parm/swio.ipe.rc
+++ b/scripts/compsets/parm/swio.ipe.rc
@@ -30,6 +30,16 @@ import_fields::
 ::
 
 #
+#  Output fields
+#
+#  List import fields to be written to file and set corresponding
+#  output variable name (optional) using the following syntax:
+#
+#  <import_field_name>    [<output_variable_name>]
+output_fields::
+::
+
+#
 #  Computed fields
 #
 #  Use SWIO internal calculator to compute additional

--- a/scripts/compsets/parm/swio.wam.rc
+++ b/scripts/compsets/parm/swio.wam.rc
@@ -17,6 +17,25 @@ import_fields::
     thermosphere_mean_molecular_mass
 ::
 #
+#  Output fields
+#
+#  List import fields to be written to file and set corresponding
+#  output variable name (optional) using the following syntax:
+#
+#  <import_field_name>    [<output_variable_name>]
+output_fields::
+    height                              wam_height_levels
+    temp_neutral
+    eastward_wind_neutral
+    northward_wind_neutral
+    upward_wind_neutral
+    O_Density
+    O2_Density
+    N2_Density
+    thermosphere_mass_density
+    thermosphere_mean_molecular_mass
+::
+#
 # Output file format.
 #
 # Choose from:


### PR DESCRIPTION
This PR updates the SWIO component to introduce the ability to select the imported fields to be included in SWIO's output files.

See SWIO [PR#3](https://github.com/NOAA-SWPC/SWIO/pull/3) for details.