### PR TITLE
WAM parameters config

### DIFF
--- a/scripts/compsets/WAM_phys_parameters_20130316.config
+++ b/scripts/compsets/WAM_phys_parameters_20130316.config
@@ -45,7 +45,7 @@ export DYNAMO_EFIELD="T"
 
 ##WAM physics parameters setting
 
-export skeddy0=180.0
+export skeddy0=140.0
 export skeddy_semiann=60.0
 export skeddy_ann=0.0
 

--- a/scripts/compsets/WAM_phys_parameters_20130316.config
+++ b/scripts/compsets/WAM_phys_parameters_20130316.config
@@ -1,0 +1,77 @@
+#!/bin/bash
+## valid mode options: WAM-IPE, standaloneWAM, standaloneIPE, standaloneGSM (WAM w/ lsidea=.false., LEVS=64)
+export MODE="WAM-IPE"
+export SWIO=".true."
+
+## user/job configuration (must be set here)
+export ACCOUNT=swpc     # computational account
+export QUEUE=batch      # computational queue
+export JOBNAME=WAM_physics_parameters_coupled
+export CDATE=2013031600 # initialization date (idate) for atmospheric/surface input (do not include the forecast hour for restarts!)
+
+## if you want the scripts to handle setting up the ROTDIR for you, you can define IC_DIR and IPE_IC_DIR as below.
+## it should contain both siganl/sfcanl valid for CDATE (e.g. s*anl.$CDATE),
+## or appropriate IPE files (e.g. IPE_State.apex.$CDATE00.h5).
+export IC_DIR=/scratch1/NCEPDEV/swpc/WAM-IPE_DATA/ICS/$MODE/$CDATE
+export IPE_IC_DIR=/scratch1/NCEPDEV/swpc/WAM-IPE_DATA/IPE_FIX
+
+# WAM IO options
+export FHMAX=1 # hours to forecast from input files. think of this as a segment length
+export FHRES=1 # hours between writing restart files
+export FHOUT=1 # frequency of standard history file output (hours)
+export FHDFI=0 # half number of hours of digital filter initialization
+export nc_output=F
+export delout_nc=3600
+export nc_fields="F, F, T, T, T, F, F, F, F, F, F, T, T"
+###############   w, z, u, v, t,qr,o3,cw, o,o2,n2,den,gmol
+
+# IPE IO options
+# IPEFREQ will default to DELTIM if unset but is required to be <=FHMAX and a multiple of DELTIM
+export IPEFREQ=3600 # seconds between IPE output
+
+# model timestep options
+export DELTIM=60      # GSM timestep
+export DELTIM_IPE=180 # IPE timestep
+
+## computational configuration (compute.config)
+export WALLCLOCK=08:00:00 # minutes
+# below only used if WAM_IPE_COUPLING=.true.
+export NPROCGSM=32
+export NPROCIPE=40
+export NPROCMED=40
+
+## IPE electrodynamics setting ("F" for empirical e-field)
+export DYNAMO_EFIELD="T"
+
+##WAM physics parameters setting
+
+export skeddy0=180.0
+export skeddy_semiann=60.0
+export skeddy_ann=0.0
+
+export tkeddy0=280.0
+export tkeddy_semiann=0.0
+export tkeddy_ann=0.0
+
+export JH0=1.75
+export JH_tanh=0.5
+export JH_semiann=0.5
+export JH_ann=0.0
+
+## FIXED INPUT PARAMETERS
+# INPUT_PARAMETERS options (default: timederive, FIX_F107=120.0, FIX_KP=3.0):
+# timeobs    - read all geomagnetic and solar input parameters from database files
+# timederive - read from database for F10.7, F10.7d, Kp, and 24h Avg Kp; derive solar wind parameters from F10.7/Kp
+# fixderive  - specify constant F10.7 (used for F10.7d) and Kp (used for 24h Avg Kp); derive as above
+# fixall     - fix all fields
+# realtime   - read from the .xml data if available, or use wam_input_f107_kp.txt provided in IC_DIR otherwise
+export INPUT_PARAMETERS=timeobs
+## if you are using fixderive or fixall, uncomment the following and set your fixed values
+# export FIX_F107=120.0     # F10.7 and F10.7d
+# export FIX_KP=3.0         # Kp and 24hr average Kp
+# export FIX_SWVEL=400.0    # solar wind velocity
+# export FIX_SWDEN=5.0      # solar wind density
+# export FIX_SWBY=1.0       # y-component of solar wind
+# export FIX_SWBZ=1.0       # z-component of solar wind
+# export FIX_GWATTS=4.5     # gigawatts
+# export FIX_HPI=2          # hemispheric power index


### PR DESCRIPTION
Add the default setting of WAM physics parameters/swiches in  scripts/compsets/WAM_phys_parameters_20130316.config. 
Doubled checked the results, the value of parameters can be changed by changing the config file, and has been confirmed in scripts/compsets/parm/wam_control_in and the running results before. 