### PR TITLE
Wam_more_parameters

### DIFF
--- a/scripts/compsets/WAM_phys_parameters.config
+++ b/scripts/compsets/WAM_phys_parameters.config
@@ -57,6 +57,8 @@ export JH0=1.75
 export JH_tanh=0.5
 export JH_semiann=0.5
 export JH_ann=0.0
+export JH_st0=25000.0
+export JH_st1=5000.0
 
 ## FIXED INPUT PARAMETERS
 # INPUT_PARAMETERS options (default: timederive, FIX_F107=120.0, FIX_KP=3.0):

--- a/scripts/compsets/coupled_20130316.config
+++ b/scripts/compsets/coupled_20130316.config
@@ -6,7 +6,7 @@ export SWIO=".true."
 ## user/job configuration (must be set here)
 export ACCOUNT=swpc     # computational account
 export QUEUE=batch      # computational queue
-export JOBNAME=coupled_march_2013
+export JOBNAME=coupled_march_2013_3days
 export CDATE=2013031600 # initialization date (idate) for atmospheric/surface input (do not include the forecast hour for restarts!)
 
 ## if you want the scripts to handle setting up the ROTDIR for you, you can define IC_DIR and IPE_IC_DIR as below.
@@ -16,11 +16,11 @@ export IC_DIR=/scratch1/NCEPDEV/swpc/WAM-IPE_DATA/ICS/$MODE/$CDATE
 export IPE_IC_DIR=/scratch1/NCEPDEV/swpc/WAM-IPE_DATA/IPE_FIX
 
 # WAM IO options
-export FHMAX=1 # hours to forecast from input files. think of this as a segment length
-export FHRES=1 # hours between writing restart files
+export FHMAX=72 # hours to forecast from input files. think of this as a segment length
+export FHRES=72 # hours between writing restart files
 export FHOUT=1 # frequency of standard history file output (hours)
 export FHDFI=0 # half number of hours of digital filter initialization
-export nc_output=F
+export nc_output=T
 export delout_nc=3600
 export nc_fields="F, F, T, T, T, F, F, F, F, F, F, T, T"
 ###############   w, z, u, v, t,qr,o3,cw, o,o2,n2,den,gmol

--- a/scripts/compsets/coupled_20130316.config
+++ b/scripts/compsets/coupled_20130316.config
@@ -6,7 +6,7 @@ export SWIO=".true."
 ## user/job configuration (must be set here)
 export ACCOUNT=swpc     # computational account
 export QUEUE=batch      # computational queue
-export JOBNAME=coupled_march_2013_3days
+export JOBNAME=coupled_march_2013
 export CDATE=2013031600 # initialization date (idate) for atmospheric/surface input (do not include the forecast hour for restarts!)
 
 ## if you want the scripts to handle setting up the ROTDIR for you, you can define IC_DIR and IPE_IC_DIR as below.
@@ -16,11 +16,11 @@ export IC_DIR=/scratch1/NCEPDEV/swpc/WAM-IPE_DATA/ICS/$MODE/$CDATE
 export IPE_IC_DIR=/scratch1/NCEPDEV/swpc/WAM-IPE_DATA/IPE_FIX
 
 # WAM IO options
-export FHMAX=72 # hours to forecast from input files. think of this as a segment length
-export FHRES=72 # hours between writing restart files
+export FHMAX=1 # hours to forecast from input files. think of this as a segment length
+export FHRES=1 # hours between writing restart files
 export FHOUT=1 # frequency of standard history file output (hours)
 export FHDFI=0 # half number of hours of digital filter initialization
-export nc_output=T
+export nc_output=F
 export delout_nc=3600
 export nc_fields="F, F, T, T, T, F, F, F, F, F, F, T, T"
 ###############   w, z, u, v, t,qr,o3,cw, o,o2,n2,den,gmol

--- a/scripts/compsets/exglobal/exglobal_fcst_nems.sh
+++ b/scripts/compsets/exglobal/exglobal_fcst_nems.sh
@@ -674,6 +674,8 @@ export JH0=${JH0:-1.75}
 export JH_tanh=${JH_tanh:-0.5}
 export JH_semiann=${JH_semiann:-0.5}
 export JH_ann=${JH_ann:-0.0}
+export JH_st0=${JH_st0:-25000.0}
+export JH_st1=${JH_st1:-5000.0}
 
 export skeddy0=${skeddy0:-140.0}
 export skeddy_semiann=${skeddy_semiann:-60.0}

--- a/scripts/compsets/parm/wam_control_in
+++ b/scripts/compsets/parm/wam_control_in
@@ -5,7 +5,7 @@
      wam_gwphys=.false., wam_solar_in=.false., wam_ion_in=.false.,
      wam_das_in=.false., wam_smet_in=.false., wam_netcdf_inout=.true.,
      wam_tides_diag=.false., wam_pws_diag=.false., wam_gws_diag=.false.,
-     JH0=$JH0, JH_tanh=$JH_tanh, JH_semiann=$JH_semiann, JH_ann=$JH_ann,
+     JH0=$JH0, JH_tanh=$JH_tanh, JH_semiann=$JH_semiann, JH_ann=$JH_ann, JH_st0=$JH_st0, JH_st1=$JH_st1,
      skeddy0=$skeddy0, skeddy_semiann=$skeddy_semiann, skeddy_ann=$skeddy_ann,
      tkeddy0=$tkeddy0, tkeddy_semiann=$tkeddy_semiann, tkeddy_ann=$tkeddy_ann
 /


### PR DESCRIPTION
The pushed branch Add two more parameters as the namelist variables in WAM base on the tip develop branch. 
They have related to the storm factor calculation to constain the Joule heating in idea_ion.f.
JH_st0 = 25000.
JH_st1 = 5000.
The parameters are already add in exglobal and the parameter .config file has been updated. 
The test run has gotten bit-by-bit WAM output with the tip develop branch. 
the corresponding WAM branch with the same name has been pushed into the WAM repository too.   