### PR TITLE
Driver parser fixes

### DIFF
--- a/scripts/interpolate_input_parameters/parse_realtime.py
+++ b/scripts/interpolate_input_parameters/parse_realtime.py
@@ -280,8 +280,9 @@ class InputParameters(object):
             for child in root.findall('data-item'):
                 time = datetime.strptime(child.get('time-tag'), WAM_INPUT_FMT)
                 try:
-                    f107[time]  = max(float(child.find('f10').text), F107_MIN)
-                    f107d[time] = max(float(child.find('f10-41-avg').text), F107D_MIN)
+                    if time.hour == 12:
+                        f107[time]  = max(float(child.find('f10').text), F107_MIN)
+                        f107d[time] = max(float(child.find('f10-41-avg').text), F107D_MIN)
                     ap[time]    = self.ap_from_kp(min(float(child.find('kp').text), KP_MAX))
                     apa[time]   = self.ap_from_kp(min(float(child.find('kp-24-hr-avg').text), KPA_MAX))
                 except:

--- a/scripts/interpolate_input_parameters/realtime_wrapper.py
+++ b/scripts/interpolate_input_parameters/realtime_wrapper.py
@@ -11,7 +11,7 @@ DEFAULT_VAR = 'f107'
 
 def touch(dt):
     with open(dt.strftime("%Y%m%d_%H%M%S.lock"), "w") as f:
-        pass
+        f.write(datetime.now().strftime('%Y%m%d_%H%M%S'))
 
 def proceed(dt):
     tdelta = datetime.now() - dt
@@ -54,8 +54,8 @@ def main():
                description='Parse KP, F10.7, 24hr average Kp, and hemispheric power files into binned data', \
                formatter_class=ArgumentDefaultsHelpFormatter \
              )
-    parser.add_argument('-c', '--current_date',help='current date of run (YYYYMMDDhhmm)', type=str, default='202102170015')
-    parser.add_argument('-e', '--end_date',    help='end date of run (YYYYMMDDhh)', type=str, default='202006010559')
+    parser.add_argument('-c', '--current_date',help='current date of run (YYYYmmddHHMM)', type=str, default='202102170015')
+    parser.add_argument('-e', '--end_date',    help='end date of run (YYYYmmddHHMM)', type=str, default='202006010559')
     parser.add_argument('-d', '--duration',    help='duration (mins) of each segment',   type=int, default=15)
     parser.add_argument('-p', '--path',        help='path to input parameters', type=str, default=prt.DEFAULT_PATH)
     parser.add_argument('-o', '--output',      help='full path to output file', type=str, default=prt.DEFAULT_NAME)
@@ -69,7 +69,9 @@ def main():
 
     target_date = current_date + timedelta(minutes=args.duration)
 
-    ip = prt.InputParameters(current_date, args.duration, args.path, args.output, True, True)
+    driver_end_date = datetime.strptime(prt.EDATE, '%Y%m%d%H%M')
+
+    ip = prt.InputParameters(current_date, args.duration, args.path, args.output, True, True, *[driver_end_date]*3)
     ip.parse()
 
     while current_date < end_date:
@@ -80,7 +82,10 @@ def main():
                 # parse
                 ip.parse()
                 # write
+                ip.outfile = 'input_parameters.nc'
                 ip.netcdf_output()
+                ip.outfile = 'wam_input_f107_kp.txt'
+                ip.output()
                 # touch and advance
                 touch(current_date)
                 current_date += timedelta(minutes=args.duration)


### PR DESCRIPTION
1. Linear interpolation performed on linear value Ap instead of Kp, Kp recalculated from Ap values.
2. Treat F10.7 as a daily value at 12UT, rather than a 3hrly value as it is in the .xml files. This will allow F10.7 to vary more smoothly rather than jumping at 21UT suddenly.
3. Add attributes to NetCDF output that define the last ingested timestamp for each of the three raw driver source files, and also allow those attributes to be fed back into the realtime parser. In this way, we can limit the "greedy" behavior of the default realtime parser, and generate driver files that are identical to the operational run even with a raw driver database with significantly more data. This is not useful operationally, but can be useful in retrospective operational runs to compare; it was used, for example, in testing the impact of the newBz branch during a storm while doing DA.